### PR TITLE
adding gitignore to remove encoded_image, decode_output and comparssi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/*
+Encoded_image/*
+Decode_output/*
+Comparison_result/*


### PR DESCRIPTION
adding .gitignore to remove encoded_image, decode_output and comparison_result folders in every PRs.
some requester may accidentally submit stego-file containing a secret message.  